### PR TITLE
Review

### DIFF
--- a/src/Observer/AddPageAssets.php
+++ b/src/Observer/AddPageAssets.php
@@ -34,12 +34,6 @@ class AddPageAssets implements ObserverInterface
         }
 
         $this->addDefaultPageAssets();
-
-        if ($this->config->getSearchType() !== SearchType::SUGGESTIONS->value) {
-            return;
-        }
-
-        $this->addSuggestionsPageAssets();
     }
 
     /**
@@ -56,18 +50,6 @@ class AddPageAssets implements ObserverInterface
         $this->addJsRemotePageAsset(
             sprintf('https://gateway.tweakwisenavigator.net/js/%s/tweakwise.js', $instanceKey),
             sprintf('https://gateway.tweakwisenavigator.com/js/%s/tweakwise.js', $instanceKey)
-        );
-    }
-
-    /**
-     * @return void
-     */
-    private function addSuggestionsPageAssets(): void
-    {
-        $this->addLinkRemotePageAsset('https://gateway.tweakwisenavigator.net/js/suggestions.js');
-        $this->addJsRemotePageAsset(
-            'https://gateway.tweakwisenavigator.net/js/suggestions.js',
-            'https://gateway.tweakwisenavigator.com/js/suggestions.js'
         );
     }
 

--- a/src/view/frontend/templates/search.phtml
+++ b/src/view/frontend/templates/search.phtml
@@ -15,7 +15,7 @@ $viewModel = $block->getViewModel();
     <script>
         const input = window['twn-starter-config'].input;
         window['twn-starter-config'].input = null;
-        window.addEventListener('DOMContentLoaded', function () {
+        window.addEventListener("twn.suggestions.ready", function () {
             window.tweakwiseSuggestions({
                 input: input,
                 instancekey: "<?= $viewModel->getInstanceKey();?>",

--- a/src/view/frontend/templates/search.phtml
+++ b/src/view/frontend/templates/search.phtml
@@ -14,8 +14,8 @@ $viewModel = $block->getViewModel();
 <?php if ($viewModel->getSearchType() === SearchType::SUGGESTIONS->value): ?>
     <script>
         const input = window['twn-starter-config'].input;
-        window['twn-starter-config'].input = null;
         window.addEventListener("twn.suggestions.ready", function () {
+            window['twn-starter-config'].input = null;
             window.tweakwiseSuggestions({
                 input: input,
                 instancekey: "<?= $viewModel->getInstanceKey();?>",

--- a/src/view/frontend/templates/search.phtml
+++ b/src/view/frontend/templates/search.phtml
@@ -14,8 +14,9 @@ $viewModel = $block->getViewModel();
 <?php if ($viewModel->getSearchType() === SearchType::SUGGESTIONS->value): ?>
     <script>
         const input = window['twn-starter-config'].input;
+        window['twn-starter-config'].input = null;
+        
         window.addEventListener("twn.suggestions.ready", function () {
-            window['twn-starter-config'].input = null;
             window.tweakwiseSuggestions({
                 input: input,
                 instancekey: "<?= $viewModel->getInstanceKey();?>",


### PR DESCRIPTION
**Remove suggestions js assets because its included in base script.**
The user can configure the use of suggestions in the plugin studio. If they enable it it's automatically included in the tweakwise.js file of the customer.

**Use specific TW event to determine suggestions script is loaded.**
There's an event fired when the suggestions script is loaded. You can use that event to load the suggestions configuration after the suggestions script has been initialized.