### PR TITLE
Fix: hyva add to

### DIFF
--- a/src/view/frontend/templates/js/category/hyva/add-to.phtml
+++ b/src/view/frontend/templates/js/category/hyva/add-to.phtml
@@ -115,9 +115,8 @@ $formKey = $viewModel->getFormKey();
             return;
         }
 
-        const $pageWrapper = document.querySelector('.page-wrapper');
         const $tweakwiseStarterOverlay = document.getElementById('twn-starter-overlay');
-        $pageWrapper.insertBefore($messages, $tweakwiseStarterOverlay);
+        $tweakwiseStarterOverlay.parentNode.insertBefore($messages, $tweakwiseStarterOverlay);
     }
 
     /**


### PR DESCRIPTION
This pull requests fixes an error you get when the elements on the page have an diffrent order. The moveMessages function gave an error that the overlay was not an child of the page-wrapper. 

This change ensures that the messages are moved to the parent of the overlay regardless which element it is.