### PR TITLE
feat: Added Personal Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ php bin/magento setup:static-content:deploy
 ## Configurations
 All settings can be found under Stores -> Configuration -> Catalog -> Tweakwise -> Tweakwise JS.
 
+## JavaScript Theme Compatibility
+All JavaScript included in this module has been developed to ensure full compatibility with both the Luma and Hyvä themes.
+The implementation avoids direct dependencies on theme-specific frontend frameworks or structures, making it flexible and reliable across different Magento 2 storefront environments.
+
 ## Contributors
 If you want to create a pull request as a contributor, use the guidelines of semantic-release. semantic-release automates the whole package release workflow including: determining the next version number, generating the release notes, and publishing the package.
 By adhering to the commit message format, a release is automatically created with the commit messages as release notes. Follow the guidelines as described in: https://github.com/semantic-release/semantic-release?tab=readme-ov-file#commit-message-format. 

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -13,9 +13,10 @@ class Config
     private const XML_PATH_ENABLED = 'tweakwise/tweakwisejs/general/enabled';
     private const XML_PATH_INSTANCE_KEY = 'tweakwise/tweakwisejs/general/instance_key';
 
-    public const XML_PATH_MERCHANDISING_ENABLED = 'tweakwise/tweakwisejs/merchandising/enabled';
+    private const XML_PATH_MERCHANDISING_ENABLED = 'tweakwise/tweakwisejs/merchandising/enabled';
 
     private const XML_PATH_SEARCH_TYPE = 'tweakwise/tweakwisejs/search/type';
+    private const XML_PATH_EVENTS_ENABLED = 'tweakwise/tweakwisejs/events/enabled';
 
     /**
      * @param ScopeConfigInterface $scopeConfig
@@ -42,15 +43,11 @@ class Config
     }
 
     /**
-     * @param string $scopeType
-     * @param null|int|string $scopeCode
      * @return bool
      */
-    public function isMerchandisingEnabled(
-        string $scopeType = ScopeInterface::SCOPE_STORE,
-        mixed $scopeCode = null
-    ): bool {
-        return $this->scopeConfig->isSetFlag(self::XML_PATH_MERCHANDISING_ENABLED, $scopeType, $scopeCode);
+    public function isMerchandisingEnabled(): bool
+    {
+        return $this->scopeConfig->isSetFlag(self::XML_PATH_MERCHANDISING_ENABLED, ScopeInterface::SCOPE_STORE);
     }
 
     /**
@@ -61,5 +58,13 @@ class Config
         return SearchType::tryFrom(
             $this->scopeConfig->getValue(self::XML_PATH_SEARCH_TYPE, ScopeInterface::SCOPE_STORE)
         ) ?? SearchType::MAGENTO_DEFAULT;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEventsEnabled(): bool
+    {
+        return $this->scopeConfig->isSetFlag(self::XML_PATH_EVENTS_ENABLED, ScopeInterface::SCOPE_STORE);
     }
 }

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -17,6 +17,7 @@ class Config
 
     private const XML_PATH_SEARCH_TYPE = 'tweakwise/tweakwisejs/search/type';
     private const XML_PATH_EVENTS_ENABLED = 'tweakwise/tweakwisejs/events/enabled';
+    private const XML_PATH_EVENTS_COOKIE_NAME = 'tweakwise/tweakwisejs/events/cookie_name';
 
     /**
      * @param ScopeConfigInterface $scopeConfig
@@ -66,5 +67,13 @@ class Config
     public function isEventsEnabled(): bool
     {
         return $this->scopeConfig->isSetFlag(self::XML_PATH_EVENTS_ENABLED, ScopeInterface::SCOPE_STORE);
+    }
+
+    /**
+     * @return string
+     */
+    public function getEventsCookieName(): string
+    {
+        return $this->scopeConfig->getValue(self::XML_PATH_EVENTS_COOKIE_NAME, ScopeInterface::SCOPE_STORE);
     }
 }

--- a/src/ViewModel/Event.php
+++ b/src/ViewModel/Event.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tweakwise\TweakwiseJs\ViewModel;
+
+use Magento\Checkout\Model\Session;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Tweakwise\TweakwiseJs\Helper\Data;
+use Tweakwise\TweakwiseJs\Model\Config;
+
+class Event implements ArgumentInterface
+{
+    /**
+     * @param Data $dataHelper
+     * @param Config $config
+     * @param Session $checkoutSession
+     * @param Json $jsonSerializer
+     */
+    public function __construct(
+        private readonly Data $dataHelper,
+        private readonly Config $config,
+        private readonly Session $checkoutSession,
+        private readonly Json $jsonSerializer
+    ) {
+    }
+
+    /**
+     * @param int $productId
+     * @return string
+     */
+    public function getTweakwiseProductId(int $productId): string
+    {
+        try {
+            return $this->dataHelper->getTweakwiseId($productId);
+        } catch (NoSuchEntityException $e) {
+            return '0';
+        }
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getInstanceKey(): ?string
+    {
+        return $this->config->getInstanceKey();
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrderProductIds(): string
+    {
+        $order = $this->checkoutSession->getLastRealOrder();
+
+        $productIds = array_map(function ($orderItem) {
+            try {
+                return $this->dataHelper->getTweakwiseId((int)$orderItem->getProductId());
+            } catch (NoSuchEntityException $e) {
+                return '0';
+            }
+        }, $order->getAllVisibleItems());
+
+        return $this->jsonSerializer->serialize($productIds);
+    }
+}

--- a/src/ViewModel/Event.php
+++ b/src/ViewModel/Event.php
@@ -51,6 +51,14 @@ class Event implements ArgumentInterface
     /**
      * @return string
      */
+    public function getEventsCookieName(): string
+    {
+        return $this->config->getEventsCookieName();
+    }
+
+    /**
+     * @return string
+     */
     public function getOrderProductIds(): string
     {
         $order = $this->checkoutSession->getLastRealOrder();

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -46,6 +46,18 @@
                         <field id="tweakwise/tweakwisejs/general/enabled">1</field>
                     </depends>
                 </group>
+                <group id="events" translate="label" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Events</label>
+                    <comment>To analyze the performance of your configuration, power our insights reports and support personalization, we capture key e-commerce events on your platform. These are events such as product views, search actions and purchases.</comment>
+                    <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1"
+                           showInStore="1">
+                        <label>Enabled</label>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    </field>
+                    <depends>
+                        <field id="tweakwise/tweakwisejs/general/enabled">1</field>
+                    </depends>
+                </group>
             </group>
         </section>
     </system>

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -8,7 +8,7 @@
                 <group id="general" translate="label" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>General</label>
                     <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>Enabled</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     </field>
@@ -25,7 +25,7 @@
                 <group id="merchandising" translate="label" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Merchandising</label>
                     <field id="enabled" translate="label comment" type="select" sortOrder="10"
-                           showInDefault="1" showInWebsite="1" showInStore="1">
+                           showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                         <label>Enabled</label>
                         <source_model>Tweakwise\TweakwiseJs\Model\Config\Source\Yesno</source_model>
                         <comment><![CDATA[Enable or disable the Tweakwise merchandising functionality<br /><strong style="color:red">Important:</strong> Save your instance key so that all options are loaded.]]></comment>
@@ -37,7 +37,7 @@
                 <group id="search" translate="label" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Search</label>
                     <field id="type" translate="label comment" type="select" sortOrder="10"
-                           showInDefault="1" showInWebsite="1" showInStore="1">
+                           showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                         <label>Type</label>
                         <source_model>Tweakwise\TweakwiseJs\Model\Config\Source\SearchType</source_model>
                         <comment><![CDATA[Choose which type of search to use<br /><strong style="color:red">Important:</strong> Save your instance key so that all options are loaded.]]></comment>
@@ -50,9 +50,18 @@
                     <label>Events</label>
                     <comment>To analyze the performance of your configuration, power our insights reports and support personalization, we capture key e-commerce events on your platform. These are events such as product views, search actions and purchases.</comment>
                     <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1"
-                           showInStore="1">
+                           showInStore="1" canRestore="1">
                         <label>Enabled</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    </field>
+                    <field id="cookie_name" translate="label comment" type="text" sortOrder="20" showInDefault="1"
+                           showInWebsite="1" showInStore="1" canRestore="1">
+                        <label>Cookie Name</label>
+                        <comment>Name of cookie which holds Tweakwise profile information</comment>
+                        <validate>required-entry</validate>
+                        <depends>
+                            <field id="enabled">1</field>
+                        </depends>
                     </field>
                     <depends>
                         <field id="tweakwise/tweakwisejs/general/enabled">1</field>

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -13,6 +13,10 @@
                 <search>
                     <type>magento_default</type>
                 </search>
+                <events>
+                    <enabled>0</enabled>
+                    <cookie_name>tw-analytics</cookie_name>
+                </events>
             </tweakwisejs>
         </tweakwise>
     </default>

--- a/src/etc/csp_whitelist.xml
+++ b/src/etc/csp_whitelist.xml
@@ -3,11 +3,13 @@
     <policies>
         <policy id="script-src">
             <values>
+                <value id="tweakwise" type="host">*.tweakwise.com</value>
                 <value id="tweakwisenavigator" type="host">*.tweakwisenavigator.net</value>
             </values>
         </policy>
         <policy id="connect-src">
             <values>
+                <value id="tweakwise" type="host">*.tweakwise.com</value>
                 <value id="tweakwisenavigator" type="host">*.tweakwisenavigator.net</value>
             </values>
         </policy>

--- a/src/view/frontend/layout/catalog_product_view.xml
+++ b/src/view/frontend/layout/catalog_product_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <block class="Magento\Framework\View\Element\Template"
+                   name="tweakwise-js-event-default"
+                   template="Tweakwise_TweakwiseJs::js/event/default.phtml"
+                   ifconfig="tweakwise/tweakwisejs/events/enabled">
+                <arguments>
+                    <argument name="view_model" xsi:type="object">Tweakwise\TweakwiseJs\ViewModel\Event</argument>
+                </arguments>
+            </block>
+            <block class="Magento\Catalog\Block\Product\View"
+                   name="tweakwise-js-event-view-product"
+                   template="Tweakwise_TweakwiseJs::js/event/view-product-event.phtml"
+                   ifconfig="tweakwise/tweakwisejs/events/enabled">
+                <arguments>
+                    <argument name="view_model" xsi:type="object">Tweakwise\TweakwiseJs\ViewModel\Event</argument>
+                </arguments>
+            </block>
+        </referenceContainer>
+    </body>
+</page>

--- a/src/view/frontend/layout/catalogsearch_result_index.xml
+++ b/src/view/frontend/layout/catalogsearch_result_index.xml
@@ -2,13 +2,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <!-- Make sure the columns container is never empty, else Magento doesn't render it -->
-        <referenceContainer name="columns">
-            <block class="Magento\Framework\View\Element\Text">
-                <arguments>
-                    <argument name="text" xsi:type="string"><![CDATA[&nbsp;]]></argument>
-                </arguments>
-            </block>
+        <referenceContainer name="content">
             <block class="Magento\Framework\View\Element\Template"
                    name="tweakwise-js-event-default"
                    template="Tweakwise_TweakwiseJs::js/event/default.phtml"
@@ -23,10 +17,5 @@
                    ifconfig="tweakwise/tweakwisejs/events/enabled">
             </block>
         </referenceContainer>
-        <move element="customer.customer.data" destination="columns"/>
-        <move element="customer.section.config" destination="columns"/>
-        <referenceContainer name="main" remove="true"/>
-        <referenceContainer name="div.sidebar.main" remove="true"/>
-        <referenceContainer name="div.sidebar.additional" remove="true"/>
     </body>
 </page>

--- a/src/view/frontend/layout/checkout_onepage_success.xml
+++ b/src/view/frontend/layout/checkout_onepage_success.xml
@@ -2,13 +2,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <!-- Make sure the columns container is never empty, else Magento doesn't render it -->
-        <referenceContainer name="columns">
-            <block class="Magento\Framework\View\Element\Text">
-                <arguments>
-                    <argument name="text" xsi:type="string"><![CDATA[&nbsp;]]></argument>
-                </arguments>
-            </block>
+        <referenceContainer name="content">
             <block class="Magento\Framework\View\Element\Template"
                    name="tweakwise-js-event-default"
                    template="Tweakwise_TweakwiseJs::js/event/default.phtml"
@@ -18,15 +12,13 @@
                 </arguments>
             </block>
             <block class="Magento\Framework\View\Element\Template"
-                   name="tweakwise-js-event-search"
-                   template="Tweakwise_TweakwiseJs::js/event/search-event.phtml"
+                   name="tweakwise-js-event-purchase"
+                   template="Tweakwise_TweakwiseJs::js/event/purchase-event.phtml"
                    ifconfig="tweakwise/tweakwisejs/events/enabled">
+                <arguments>
+                    <argument name="view_model" xsi:type="object">Tweakwise\TweakwiseJs\ViewModel\Event</argument>
+                </arguments>
             </block>
         </referenceContainer>
-        <move element="customer.customer.data" destination="columns"/>
-        <move element="customer.section.config" destination="columns"/>
-        <referenceContainer name="main" remove="true"/>
-        <referenceContainer name="div.sidebar.main" remove="true"/>
-        <referenceContainer name="div.sidebar.additional" remove="true"/>
     </body>
 </page>

--- a/src/view/frontend/templates/js/event/default.phtml
+++ b/src/view/frontend/templates/js/event/default.phtml
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types = 1);
+
+use Magento\Framework\View\Element\Template;
+use Tweakwise\TweakwiseJs\ViewModel\Event;
+
+/** @var Template $block */
+
+/** @var Event $eventViewModel */
+$eventViewModel = $block->getViewModel();
+?>
+<script>
+    (function (w, d, l, i, p, u) {
+
+        w['_twa'] = l;
+        w[l] = w[l] || [];
+        w[l].push({'twa.start': new Date().getTime(), event: 'twa.js'});
+        w[l].push({'twa.instance': i, event: 'twa.init'});
+
+        p && w[l].push({'twa.profile': p, event: 'twa.profile'});
+        if (p) {
+            w[l].getProfileKey = function () {
+                return p;
+            }
+        }
+
+        var f = d.getElementsByTagName('script')[0],
+            j = d.createElement('script');
+        j.async = true;
+        j.src = u;
+        f.parentNode.insertBefore(j, f);
+
+    })(window, document, 'tweakwiseLayer', '<?= $eventViewModel->getInstanceKey() ?>', getProfileKey(), "//navigator-analytics.tweakwise.com/bundles/scout.js");
+
+    /**
+     * @param {Object} event
+     */
+    function pushEvent(event) {
+        tweakwiseLayer.push(event);
+    }
+
+    /**
+     * @returns {string}
+     */
+    function getProfileKey() {
+        const profileKey = getProfileKeyFromCookie();
+
+        if (profileKey) {
+            return profileKey;
+        }
+
+        return generateProfileKey();
+    }
+
+    /**
+     * @returns {string}
+     */
+    function getProfileKeyFromCookie() {
+        const cookieName = 'tw-analytics';
+        const value = `; ${document.cookie}`;
+        const parts = value.split(`; ${cookieName}=`);
+        if (parts.length === 2) return parts.pop().split(';').shift();
+    }
+
+    /**
+     * @returns {string}
+     */
+    function generateProfileKey() {
+        const CHARS_LOWERS = 'abcdefghijklmnopqrstuvwxyz';
+        const CHARS_UPPERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        const CHARS_DIGITS = '0123456789';
+        const chars = CHARS_LOWERS + CHARS_UPPERS + CHARS_DIGITS;
+
+        let profileKey = '';
+        const maxIndex = chars.length - 1;
+
+        for (let i = 0; i < 32; i++) {
+            const randomIndex = Math.floor(Math.random() * (maxIndex + 1));
+            profileKey += chars[randomIndex];
+        }
+
+        return profileKey;
+    }
+</script>

--- a/src/view/frontend/templates/js/event/default.phtml
+++ b/src/view/frontend/templates/js/event/default.phtml
@@ -9,6 +9,7 @@ use Tweakwise\TweakwiseJs\ViewModel\Event;
 
 /** @var Event $eventViewModel */
 $eventViewModel = $block->getViewModel();
+$eventsCookieName = $eventViewModel->getEventsCookieName();
 ?>
 <script>
     (function (w, d, l, i, p, u) {
@@ -44,20 +45,23 @@ $eventViewModel = $block->getViewModel();
      * @returns {string}
      */
     function getProfileKey() {
-        const profileKey = getProfileKeyFromCookie();
+        let profileKey = getProfileKeyFromCookie();
 
         if (profileKey) {
             return profileKey;
         }
 
-        return generateProfileKey();
+        profileKey = generateProfileKey();
+        setCookie(profileKey);
+
+        return profileKey;
     }
 
     /**
      * @returns {string}
      */
     function getProfileKeyFromCookie() {
-        const cookieName = 'tw-analytics';
+        const cookieName = '<?= $eventsCookieName ?>';
         const value = `; ${document.cookie}`;
         const parts = value.split(`; ${cookieName}=`);
         if (parts.length === 2) return parts.pop().split(';').shift();
@@ -81,5 +85,16 @@ $eventViewModel = $block->getViewModel();
         }
 
         return profileKey;
+    }
+
+    /**
+     * @param {string} profileKey
+     */
+    function setCookie(profileKey) {
+        const cookieName = '<?= $eventsCookieName ?>';
+        const expirationDate = new Date();
+        expirationDate.setTime(expirationDate.getTime() + 86400000);
+
+        document.cookie = `${cookieName}=${encodeURIComponent(profileKey)}; expires=${expirationDate.toGMTString()}; path=/; secure; SameSite=lax`
     }
 </script>

--- a/src/view/frontend/templates/js/event/purchase-event.phtml
+++ b/src/view/frontend/templates/js/event/purchase-event.phtml
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+use Magento\Catalog\Block\Product\View;
+use Tweakwise\TweakwiseJs\ViewModel\Event;
+
+/** @var View $block */
+
+/** @var Event $eventViewModel */
+$eventViewModel = $block->getViewModel();
+?>
+<script>
+    pushEvent({
+        event: 'purchase',
+        data: {
+            profileKey: getProfileKey(),
+            productKeys: <?= $eventViewModel->getOrderProductIds() ?>
+        }
+    });
+</script>

--- a/src/view/frontend/templates/js/event/search-event.phtml
+++ b/src/view/frontend/templates/js/event/search-event.phtml
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types = 1);
+
+use Magento\Catalog\Block\Product\View;
+
+/** @var View $block */
+?>
+<script>
+    pushEvent({
+        event: 'search',
+        data: {
+            profileKey: getProfileKey(),
+            searchTerm: getSearchTerm()
+        }
+    });
+
+    /**
+     * @returns {string}
+     */
+    function getSearchTerm() {
+        const params = new URLSearchParams(window.location.search);
+        const searchTerm = params.get('q');
+
+        if (searchTerm) {
+            return searchTerm;
+        }
+
+        const hash = window.location.hash.substring(1);
+        const parts = hash.split('|');
+        if (parts.length > 1) {
+            const params = new URLSearchParams(parts[1]);
+            return params.get('tn_q');
+        }
+
+        return '';
+    }
+</script>

--- a/src/view/frontend/templates/js/event/view-product-event.phtml
+++ b/src/view/frontend/templates/js/event/view-product-event.phtml
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+use Magento\Catalog\Block\Product\View;
+use Tweakwise\TweakwiseJs\ViewModel\Event;
+
+/** @var View $block */
+
+/** @var Event $eventViewModel */
+$eventViewModel = $block->getViewModel();
+?>
+<script>
+    pushEvent({
+        event: 'productView',
+        data: {
+            profileKey: getProfileKey(),
+            productKey: '<?= $eventViewModel->getTweakwiseProductId((int)$block->getProduct()->getId()) ?>'
+        }
+    });
+</script>


### PR DESCRIPTION
This merge request introduces support for personal events tracking, including the following events:

1. `productView`
2. `search`
3. `purchase`

Each event is enriched with a personal profile key, allowing for more precise and personalized tracking of user interactions. This functionality is implemented in a way that is compatible with both Luma and Hyvä themes.